### PR TITLE
Needed to start jekyll project using 'bundle exec jekyll serve'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,24 @@
+source "https://rubygems.org"
+ruby RUBY_VERSION
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "3.3.1"
+
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+gem "minima", "~> 2.0"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+   gem "jekyll-feed", "~> 0.6"
+end


### PR DESCRIPTION
I am new to jekyll. So after downloading this. I went to https://jekyllrb.com/ for installation instructions. On running ```bundle exec jekyll serve``` inside the root directory of the project, I got this error ```Could not locate Gemfile or .bundle/ directory``` so I added this file which was generated by jekyll it self. And tried running the command again and now I have my website running on ```http://127.0.0.1:4000/startbootstrap-freelancer-jekyll/```.